### PR TITLE
add endpoint 5-PATCH-api-article-article_id with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -97,8 +97,32 @@ describe("NC News App", () => {
             });
           });
     });
-    test("Status: 400 for route BAD REQUEST - Not a valid patch input on votes", () => {
+    test("Status: 400 for route BAD REQUEST - Empty patch input on votes", () => {
       const articleUpdates = {};
+      return request(app)
+        .patch("/api/articles/1")
+        .send(articleUpdates)
+        .expect(400)
+        .then(({ body: { msg } }) => {
+        expect(msg).toBe("Bad Request - Invalid Input");
+        });
+    });
+    test("Status: 400 for route BAD REQUEST - Invalid key on inc_votes", () => {
+      const articleUpdates = { 
+        enc_botes: 5
+      };
+      return request(app)
+        .patch("/api/articles/1")
+        .send(articleUpdates)
+        .expect(400)
+        .then(({ body: { msg } }) => {
+        expect(msg).toBe("Bad Request - Invalid Input");
+        });
+    });
+    test("Status: 400 for route BAD REQUEST - Invalid values in inc_votes", () => {
+      const articleUpdates = { 
+        inc_votes: "Hi"
+      };
       return request(app)
         .patch("/api/articles/1")
         .send(articleUpdates)


### PR DESCRIPTION
Hello,
Added a few more tests for inc_votes. 
The tests in the previous endpoint (GET /api/article/article_id) should cover errors regarding invalid api paths - Save duplicating. 
I don't think you can see these ones though.

Thank for the feedback.